### PR TITLE
Use numerical nodeType

### DIFF
--- a/whitespace.js
+++ b/whitespace.js
@@ -9,11 +9,11 @@ function defaultBlockTest (node) {
 }
 
 function isText (node) {
-  return node && node.nodeType === Node.TEXT_NODE
+  return node && node.nodeType === 3
 }
 
 function isElem (node) {
-  return node && node.nodeType === Node.ELEMENT_NODE
+  return node && node.nodeType === 1
 }
 
 /**


### PR DESCRIPTION
I am using this script to clean up DOM trees generated by jsdom, and have encountered errors with referencing `Node` (e.g. `Node.TEXT_NODE` and `Node.ELEMENT_NODE`).

This pull request fixes those issues by using the numerical nodeTypes.
