### PR TITLE
Add support for isPre-hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ For more examples of what `collapse-whitespace` does, check out the [test page](
 
 `collapse-whitespace` exposes a single function (called `collapse` if you're including this module via a `script` tag).
 
-### collapse(node [, isBlock])
+### collapse(node [, isBlock [, isPre]])
 
-Removes all extraneous whitespace from the given node. By default, `collapse-whitespace` relies on a theoretical [list][blocks] of block elements to determine which elements are block and which ones are inline. This list may be unsuitable for your needs; the optional parameter `isBlock` can be used to tweak this behaviour. `isBlock` should be a function that accepts a DOM node and returns a Boolean.
+Removes all extraneous whitespace from the given node. By default, `collapse-whitespace` relies on a theoretical [list][blocks] of block elements to determine which elements are block and which ones are inline. This list may be unsuitable for your needs; the optional parameter `isBlock` can be used to tweak this behaviour. `isBlock` should be a function that accepts a DOM node and returns a Boolean. 
 
 Note that `collapse-whitespace` also does not take into account the parent(s) of the given node:
 
@@ -63,6 +63,8 @@ Note that `collapse-whitespace` also does not take into account the parent(s) of
   <span class="test">Lots of whitespace around this text.</span>
 </pre>
 ```
+
+By default only `PRE` nodes have whitespace preserved, but this can be customized via the optional `isPre` parameter. `isPre` should be a function that accepts a DOM node and returns a Boolean.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For more examples of what `collapse-whitespace` does, check out the [test page](
 
 ### collapse(node [, isBlock [, isPre]])
 
-Removes all extraneous whitespace from the given node. By default, `collapse-whitespace` relies on a theoretical [list][blocks] of block elements to determine which elements are block and which ones are inline. This list may be unsuitable for your needs; the optional parameter `isBlock` can be used to tweak this behaviour. `isBlock` should be a function that accepts a DOM node and returns a Boolean. 
+Removes all extraneous whitespace from the given node. By default, `collapse-whitespace` relies on a theoretical [list][blocks] of block elements to determine which elements are block and which ones are inline. This list may be unsuitable for your needs; the optional parameter `isBlock` can be used to tweak this behaviour. `isBlock` should be a function that accepts a DOM node and returns a Boolean.
 
 Note that `collapse-whitespace` also does not take into account the parent(s) of the given node:
 

--- a/src/whitespace.js
+++ b/src/whitespace.js
@@ -21,6 +21,18 @@ function isBlockElem (node) {
 }
 
 /**
+ * isPreElem(node) determines if the given node is a PRE element.
+ * 
+ * Whitespace for PRE elements are not collapsed.
+ * 
+ * @param {Node} node
+ * @return {Boolean}
+ */
+function isPreElem (node) {
+  return node.nodeName === 'PRE';
+}
+
+/**
  * isVoid(node) determines if the given node is a void element.
  *
  * @param {Node} node
@@ -40,18 +52,22 @@ function isVoid (node) {
  * @param {Node} elem
  * @param {Function} blockTest
  */
-function collapseWhitespace (elem, isBlock) {
+function collapseWhitespace (elem, isBlock, isPre) {
   if (!elem.firstChild || elem.nodeName === 'PRE') return
 
   if (typeof isBlock !== 'function') {
     isBlock = isBlockElem
   }
 
+  if (typeof isPre !== 'function') {
+    isPre = isPreElem;
+  }
+
   let prevText = null
   let prevVoid = false
 
   let prev = null
-  let node = next(prev, elem)
+  let node = next(prev, elem, isPre)
 
   while (node !== elem) {
     if (node.nodeType === 3 || node.nodeType === 4) { // Node.TEXT_NODE or Node.CDATA_SECTION_NODE
@@ -69,6 +85,7 @@ function collapseWhitespace (elem, isBlock) {
       }
 
       node.data = text
+      
       prevText = node
     } else if (node.nodeType === 1) { // Node.ELEMENT_NODE
       if (isBlock(node) || node.nodeName === 'BR') {
@@ -88,7 +105,7 @@ function collapseWhitespace (elem, isBlock) {
       continue
     }
 
-    let nextNode = next(prev, node)
+    let nextNode = next(prev, node, isPre)
     prev = node
     node = nextNode
   }
@@ -117,15 +134,16 @@ function remove (node) {
 }
 
 /**
- * next(prev, current) returns the next node in the sequence, given the
+ * next(prev, current, isPre) returns the next node in the sequence, given the
  * current and previous nodes.
  *
  * @param {Node} prev
  * @param {Node} current
+ * @param {Function} isPre
  * @return {Node}
  */
-function next (prev, current) {
-  if ((prev && prev.parentNode === current) || current.nodeName === 'PRE') {
+function next (prev, current, isPre) {
+  if ((prev && prev.parentNode === current) || isPre(current)) {
     return current.nextSibling || current.parentNode
   }
 

--- a/whitespace.d.ts
+++ b/whitespace.d.ts
@@ -1,1 +1,1 @@
-export default function(node: Node, blockTest?: (node: Node) => boolean);
+export default function(node: Node, blockTest?: (node: Node) => boolean, preTest?: (node: Node) => boolean);


### PR DESCRIPTION
Following the discussion in the previous PR (#10) - here's a better approach that allows the consumer to define nodes that should preserve whitespace. By default, only `PRE` tags will have this behaviour.