### PR TITLE
Add support for ES6/ES2015 module loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Remove unnecessary whitespace from an element.",
   "main": "lib/whitespace.js",
   "types": "whitespace.d.ts",
+  "module": "src/whitespace.js",
+  "jsnext:main": "src/whitespace.js",
   "scripts": {
     "prepublish": "make",
     "test": "make test"

--- a/src/whitespace.js
+++ b/src/whitespace.js
@@ -150,4 +150,4 @@ function next (prev, current, isPre) {
   return current.firstChild || current.nextSibling || current.parentNode
 }
 
-module.exports = collapseWhitespace
+export default collapseWhitespace

--- a/src/whitespace.js
+++ b/src/whitespace.js
@@ -22,9 +22,9 @@ function isBlockElem (node) {
 
 /**
  * isPreElem(node) determines if the given node is a PRE element.
- * 
+ *
  * Whitespace for PRE elements are not collapsed.
- * 
+ *
  * @param {Node} node
  * @return {Boolean}
  */
@@ -85,7 +85,7 @@ function collapseWhitespace (elem, isBlock, isPre) {
       }
 
       node.data = text
-      
+
       prevText = node
     } else if (node.nodeType === 1) { // Node.ELEMENT_NODE
       if (isBlock(node) || node.nodeName === 'BR') {


### PR DESCRIPTION
This pull request adds support for ES6/ES2015 module loading by using `export default` rather than `module.exports = ` in the source, as well as updating the `module` and `jsnext:main` fields in `package.json`.

I am currently using `collapse-whitespace` and `void-elements` in [Turndown](https://github.com/domchristie/to-markdown/tree/turndown) and noticed that the `voidElements` array was being duplicated in the build version. It seems that [Rollup](https://github.com/rollup/rollup) is unable to squash identical imports when using CommonJS modules. Using ES6 module exports seems to fix this issue.