### PR TITLE
Specify explicit return-type in TS declaration

### DIFF
--- a/whitespace.d.ts
+++ b/whitespace.d.ts
@@ -1,1 +1,1 @@
-export default function(node: Node, blockTest?: (node: Node) => boolean, preTest?: (node: Node) => boolean);
+export default function(node: Node, blockTest?: (node: Node) => boolean, preTest?: (node: Node) => boolean): void;


### PR DESCRIPTION
Fixes this TS error:

TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.